### PR TITLE
correct menarche float error

### DIFF
--- a/BoadiceaCanrisk.php
+++ b/BoadiceaCanrisk.php
@@ -444,7 +444,7 @@ class BoadiceaCanrisk extends AbstractExternalModule
 		
 		foreach($recordData as $thisEvent) {
 			if($thisEvent["age_first_period"] != "") {
-				$menarche = $thisEvent["age_first_period"];
+				$menarche = intval($thisEvent["age_first_period"]);
 			}
 			if($thisEvent["boadicea_pedigree_string"] != "") {
 				$previousBoadiceaString = $thisEvent["boadicea_pedigree_string"] ;


### PR DESCRIPTION
Error with age, likely because of the ".5" added onto the age: 'CanRisk header format contains an error in: ##menarche=13.5''CanRisk header format contains an error in: ##menarche=13.5'.